### PR TITLE
Add Quadroid JEDI Code Format engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
                     "enum": [
                         "embarcadero",
                         "jcf",
+                        "jcf-quadroid",
                         "ptop"
                     ]
                 },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -189,10 +189,13 @@ export async function activate(context: vscode.ExtensionContext) {
                 const optionJCF = <vscode.MessageItem>{
                     title: "Jedi Code Format"
                 };
+                const optionJCFQ = <vscode.MessageItem>{
+                    title: "JCF (Quadroid)"
+                };
                 const optionPTOP = <vscode.MessageItem>{
                     title: "FreePascal PtoP"
                 };
-                vscode.window.showErrorMessage('The "pascal.formatter.engine" setting is not defined. Do you want to download some formatter tool first?', optionJCF, optionPTOP).then(option => {
+                vscode.window.showErrorMessage('The "pascal.formatter.engine" setting is not defined. Do you want to download some formatter tool first?', optionJCF, optionJCFQ, optionPTOP).then(option => {
                     // nothing selected
                     if (typeof option === 'undefined') {
                         reject('undefined');
@@ -202,6 +205,10 @@ export async function activate(context: vscode.ExtensionContext) {
                     switch (option.title) {
                         case optionJCF.title:
                             vscode.env.openExternal(vscode.Uri.parse("http://jedicodeformat.sourceforge.net/"));
+                            break;
+
+                        case optionJCFQ.title:
+                            vscode.env.openExternal(vscode.Uri.parse("https://github.com/quadroid/jcf-pascal-format"));
                             break;
 
                         case optionPTOP.title:


### PR DESCRIPTION
Adds an option for my JEDI Code Format fork which supports inline Delphi variables and offers more indentation options. More [here](https://github.com/quadroid/jcf-pascal-format).

Also strip UTF BOM when reading formatted files back (otherwise they end up in the editor). This is quite important because Delphi UTF-8 source files are required to have BOM on them.

Also closes #5.