### PR TITLE
Fix concurrent formatting race on shared temp files (#105)

### DIFF
--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -8,6 +8,7 @@ import fs = require('fs');
 import cp = require('child_process');
 import os = require('os');
 import npath = require('path');
+import crypto = require('crypto');
 import { l10n } from 'vscode';
 
 /*
@@ -50,9 +51,13 @@ export class Formatter {
             );
 
             const textToFormat = this._document.getText(range);
-            const tempFile: string = npath.join(os.tmpdir(), 'tmp.tmp.pas');
+            // use a unique temp file name per invocation, so concurrent formatting of
+            // multiple files (e.g. bulk search and replace with format on save) can't
+            // race on a shared temp file and corrupt each other's content
+            const uniqueId = crypto.randomUUID();
+            const tempFile: string = npath.join(os.tmpdir(), `pascal-formatter-${uniqueId}.pas`);
             let command: string;
-            const tempFileOut: string = npath.join(os.tmpdir(), 'tmp.tmp.out');
+            const tempFileOut: string = npath.join(os.tmpdir(), `pascal-formatter-${uniqueId}.out`);
             let readFile: string;
             let configFileParameters = '';
 
@@ -112,12 +117,19 @@ export class Formatter {
                         readFile = tempFileOut
                     }
 
+                    const cleanupTempFiles = () => {
+                        for (const file of [tempFile, tempFileOut]) {
+                            fs.unlink(file, () => { /* best-effort cleanup, ignore errors */ });
+                        }
+                    };
+
                     console.log(command);
                     cp.exec(command, { cwd }, function(error, stdout, stderr) {
                         console.log('stdout' + stdout);
                         console.log('error' + error);
                         console.log('stderr' + stderr);
                         if (error) {
+                            cleanupTempFiles();
                             reject(stdout.toString());
                         }
                         else {
@@ -126,6 +138,7 @@ export class Formatter {
                             if (formattedXml.charCodeAt(0) === 0xfeff) {
                                 formattedXml = formattedXml.substr(1);
                             }
+                            cleanupTempFiles();
                             resolve(formattedXml);
                         }
                     });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -128,18 +128,22 @@ export class Formatter {
                         console.log('stdout' + stdout);
                         console.log('error' + error);
                         console.log('stderr' + stderr);
-                        if (error) {
-                            cleanupTempFiles();
-                            reject(stdout.toString());
-                        }
-                        else {
-                            let formattedXml: string = fs.readFileSync(readFile, 'utf8');
-                            // remove UTF-8 BOM
-                            if (formattedXml.charCodeAt(0) === 0xfeff) {
-                                formattedXml = formattedXml.substr(1);
+                        try {
+                            if (error) {
+                                reject(stdout.toString());
                             }
+                            else {
+                                let formattedXml: string = fs.readFileSync(readFile, 'utf8');
+                                // remove UTF-8 BOM
+                                if (formattedXml.charCodeAt(0) === 0xfeff) {
+                                    formattedXml = formattedXml.substr(1);
+                                }
+                                resolve(formattedXml);
+                            }
+                        } catch (readError) {
+                            reject(readError.toString());
+                        } finally {
                             cleanupTempFiles();
-                            resolve(formattedXml);
                         }
                     });
 

--- a/src/test/suite/formatter.test.ts
+++ b/src/test/suite/formatter.test.ts
@@ -1,0 +1,83 @@
+/*---------------------------------------------------------------------------------------------
+*  Copyright (c) Alessandro Fragnani. All rights reserved.
+*  Licensed under the MIT License. See License.md in the project root for license information.
+*--------------------------------------------------------------------------------------------*/
+
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { Formatter } from '../../formatter';
+
+suite('Formatter Concurrency Test Suite', () => {
+	let fixturesDir: string;
+	let enginePath: string;
+
+	suiteSetup(() => {
+		// Build a tiny cross-platform "fake engine" that mimics a ptop-style
+		// external formatter: it receives an input file and an output file,
+		// waits a small random delay (to widen any race window), and copies
+		// the input content to the output file unchanged.
+		fixturesDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pascal-formatter-test-'));
+
+		const fakeEngineJs = path.join(fixturesDir, 'fake-engine.js');
+		fs.writeFileSync(fakeEngineJs, `
+			const fs = require('fs');
+			const [, , inFile, outFile] = process.argv;
+			const content = fs.readFileSync(inFile, 'utf8');
+			setTimeout(() => fs.writeFileSync(outFile, content), Math.random() * 40);
+		`);
+
+		// use the current Node executable directly (process.execPath) instead of
+		// relying on "node" being resolvable on PATH from the extension host's
+		// spawned shell, which is not guaranteed across platforms/CI
+		const nodeExecutable = process.execPath;
+
+		if (process.platform === 'win32') {
+			enginePath = path.join(fixturesDir, 'fake-engine.cmd');
+			fs.writeFileSync(enginePath, `@echo off\r\n"${nodeExecutable}" "${fakeEngineJs}" %*\r\n`);
+		} else {
+			enginePath = path.join(fixturesDir, 'fake-engine.sh');
+			fs.writeFileSync(enginePath, `#!/bin/sh\n"${nodeExecutable}" "${fakeEngineJs}" "$@"\n`);
+			fs.chmodSync(enginePath, 0o755);
+		}
+	});
+
+	suiteTeardown(() => {
+		fs.rmSync(fixturesDir, { recursive: true, force: true });
+	});
+
+	test('concurrent format() calls do not cross-contaminate content (issue #105)', async function () {
+		this.timeout(20000);
+
+		const documentCount = 6;
+		const iterations = 3;
+
+		for (let iteration = 0; iteration < iterations; iteration++) {
+			const documents = await Promise.all(
+				Array.from({ length: documentCount }, (_, i) =>
+					vscode.workspace.openTextDocument({
+						language: 'pascal',
+						content: `unit Doc${iteration}_${i};\n\ninterface\n\nimplementation\n\nend.\n`
+					})
+				)
+			);
+
+			const results = await Promise.all(
+				documents.map(document => {
+					const formatter = new Formatter(document);
+					return formatter.format(undefined as unknown as vscode.Range, 'ptop', enginePath, '', 0, 0);
+				})
+			);
+
+			documents.forEach((document, i) => {
+				assert.strictEqual(
+					results[i],
+					document.getText(),
+					`Result for document ${i} in iteration ${iteration} was contaminated by another concurrent format() call`
+				);
+			});
+		}
+	});
+});

--- a/src/test/suite/formatter.test.ts
+++ b/src/test/suite/formatter.test.ts
@@ -67,7 +67,12 @@ suite('Formatter Concurrency Test Suite', () => {
 			const results = await Promise.all(
 				documents.map(document => {
 					const formatter = new Formatter(document);
-					return formatter.format(undefined as unknown as vscode.Range, 'ptop', enginePath, '', 0, 0);
+					const fullRange = new vscode.Range(
+						0, 0,
+						document.lineCount,
+						document.lineAt(document.lineCount - 1).range.end.character
+					);
+					return formatter.format(fullRange, 'ptop', enginePath, '', 0, 0);
 				})
 			);
 


### PR DESCRIPTION
Fixes #105

## Summary

`Formatter.format()` wrote the text to be formatted to a **hard-coded,
shared temp file path** (`os.tmpdir()/tmp.tmp.pas` / `tmp.tmp.out`) on every
invocation. When VS Code triggers concurrent format requests for multiple
files — e.g. a bulk Search and Replace across files with
`editor.formatOnSave: true` — these shared paths race: one file's write can
overwrite another's in-flight temp file (or its result), corrupting content
between unrelated files, exactly as reported.

## Changes

- `src/formatter.ts`: each `format()` call now uses a **unique** temp file
  name (`pascal-formatter-<uuid>.pas` / `.out`, via `crypto.randomUUID()`),
  eliminating the shared-state race.
- Best-effort cleanup (`fs.unlink`) of the temp files after use (both
  success and error paths), since unique names would otherwise leak files
  into the OS temp directory over time.
- `src/test/suite/formatter.test.ts` (new): a regression test that formats
  several documents **concurrently** against a small fake external engine
  and asserts no cross-contamination between them. Confirmed it **fails
  deterministically against the previous implementation** and **passes
  reliably with the fix**.

## Validation

- `npm run lint`
- `npm run test-compile`
- `npm test` (full Extension Host suite, including the new regression test)

## Implementation plan (for documentation purposes)

# Plan: Fix issue #105 — Bulk Search & Replace corrupts files with formatOnSave

> **Status: Implemented and verified.** Fix and regression test landed on
> branch `fix/105-concurrent-format-temp-file-race` (PR opened against
> `master`). `npm run lint`, `npm run test-compile`, and `npm test` all pass.
> The new test was confirmed to fail deterministically (3/3 runs) against
> the pre-fix code and pass reliably after the fix.

## Issue verification

**Confirmed real bug.** `src/formatter.ts` writes the text to be formatted to a
**fixed, hard-coded temp file path** shared by every `Formatter.format()` call:

```ts
const tempFile: string = npath.join(os.tmpdir(), 'tmp.tmp.pas');
const tempFileOut: string = npath.join(os.tmpdir(), 'tmp.tmp.out');
...
fs.writeFileSync(tempFile, textToFormat);   // sync write
...
cp.exec(command, { cwd }, function (error, stdout, stderr) { ... });  // async
```

When VS Code performs a bulk "Search and Replace" across multiple files with
`editor.formatOnSave: true`, it triggers a `formatDocument` request per file in
rapid succession. Because every call reuses the **same** `tmp.tmp.pas` /
`tmp.tmp.out` paths and the external engine invocation is asynchronous
(`cp.exec`), a second file's `writeFileSync` can overwrite the temp file
before the first file's engine process has read it, or the first file's
result can be overwritten before it's read back — a classic TOCTOU /
concurrency race. The proposed root cause in the issue (shared temp file
path) matches the code exactly, and the fix direction (unique temp paths per
invocation) is correct and sufficient to resolve it.

## Fix approach

1. **Generate a unique temp file name per `format()` invocation** instead of
   the fixed `tmp.tmp.pas` / `tmp.tmp.out`, e.g.
   `pascal-formatter-<uuid>.pas` / `pascal-formatter-<uuid>.out` in
   `os.tmpdir()`, using `crypto.randomUUID()` (Node builtin, no new
   dependency).
2. **Clean up temp files after use** (best-effort `fs.unlink`, non-fatal on
   failure) once the formatted content has been read back, since unique
   names would otherwise leak files into the OS temp dir over time. Do this
   for both the success and error paths.
3. Keep all other behavior (command construction per engine, options
   handling) unchanged — this is a targeted concurrency fix, not a rewrite.
4. No changes needed to `package.json`, localization, or other source files;
   `src/formatter.ts` is the only file affected.

## Tests

Existing test suite (`src/test/suite/extension.test.ts`) runs under
`@vscode/test-electron` (real Extension Host, real `vscode` module) — the
new test will live alongside it as `src/test/suite/formatter.test.ts` so it
can use real `vscode.workspace.openTextDocument` and the real `Formatter`
class (which depends on `vscode.TextDocument`).

**Test strategy — reproduce the race directly (no real external engine
required):**

1. In `suiteSetup`, dynamically create a tiny cross-platform "fake engine" in
   a temp directory:
   - `fake-engine.js`: reads the input file path (`argv[2]`), waits a small
     random delay (to widen the race window), then writes the same content
     to the output file path (`argv[3]`). This mimics a `ptop`-style engine
     (`"$path" "$file" "$outfile"`).
   - A tiny OS-specific launcher pointed at by `enginePath`, since
     `Formatter` wraps the engine path in quotes with no room to prepend an
     interpreter: `fake-engine.sh` (POSIX, `chmod +x`, shebang invoking
     `node`) and `fake-engine.cmd` (Windows, `node "%~dp0fake-engine.js" %*`).
     Select by `process.platform === 'win32'`.
2. Open several in-memory documents (`vscode.workspace.openTextDocument`)
   with distinct, uniquely-identifiable Pascal content (e.g. `unit Doc0;`,
   `unit Doc1;`, …).
3. Call `new Formatter(doc, options).format(undefined, 'ptop', enginePath, '', 0, 0)`
   for all documents **concurrently** via `Promise.all`.
4. Assert each resolved result equals that specific document's original
   content (the fake engine is a pure copy, so any cross-contamination from
   shared temp files would make two results identical/swapped).
5. Repeat the concurrent batch a few iterations to make the assertion
   robust/deterministic post-fix (unique temp names remove the race
   entirely, so this should never flake once fixed).
6. `suiteTeardown` removes the temp fixture directory.

This test is a regression guard: it fails reliably against the current code
path's *design* once fixed (deterministically passes), and documents/asserts
the exact concurrency scenario from the issue (parallel `format()` calls
racing on temp files).

## Files to change

- `src/formatter.ts` — unique temp file names + cleanup.
- `src/test/suite/formatter.test.ts` (new) — concurrency regression test.

## Validation

- `npm run lint`
- `npm run test-compile`
- `npm test` (runs the full Extension Host suite, including the new test)
